### PR TITLE
panel variable interpolation and datasource query variables

### DIFF
--- a/src/VariableQueryEditor.tsx
+++ b/src/VariableQueryEditor.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { SplunkQuery } from './types';
+import { TextArea } from '@grafana/ui';
+
+interface VariableQueryProps {
+  query: SplunkQuery;
+  onChange: (query: SplunkQuery, definition: string) => void;
+}
+
+export const VariableQueryEditor = ({ onChange, query }: VariableQueryProps) => {
+  const [state, setState] = useState(query);
+
+  const saveQuery = () => {
+    onChange(state, `${state.queryText}`);
+  };
+
+  const handleChange = (event: React.FormEvent<HTMLTextAreaElement>) =>
+    setState({
+      ...state,
+      [event.currentTarget.name]: event.currentTarget.value,
+    });
+
+  return (
+    <div className="gf-form">
+      <TextArea name="queryText" onBlur={saveQuery} onChange={handleChange} value={state.queryText} />
+    </div>
+  );
+};

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,9 @@ import { DataSource } from './datasource';
 import { ConfigEditor } from './ConfigEditor';
 import { QueryEditor } from './QueryEditor';
 import { SplunkQuery, SplunkDataSourceOptions } from './types';
+import { VariableQueryEditor } from './VariableQueryEditor';
 
 export const plugin = new DataSourcePlugin<DataSource, SplunkQuery, SplunkDataSourceOptions>(DataSource)
   .setConfigEditor(ConfigEditor)
-  .setQueryEditor(QueryEditor);
+  .setQueryEditor(QueryEditor)
+  .setVariableQueryEditor(VariableQueryEditor);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,15 @@
 import { DataQuery, DataSourceJsonData } from '@grafana/data';
 
+export interface QueryRequestResults {
+  fields: any[];
+  results: any[];
+}
+
+export const defaultQueryRequestResults: QueryRequestResults = {
+  fields: [],
+  results: [],
+};
+
 export interface SplunkQuery extends DataQuery {
   queryText: string;
 }


### PR DESCRIPTION
Added a few features that were helpful for me. 
* Search to query variable creation, eg. `index=_introspection | stats count by host | fields host` -> $host
* Panel query variable interpolation, eg. `index=_introspection host="$host"`
* Panel queries allow leading functions in addition to regular searching, eg. `| inputlookup mylookup`

Also, stops queries from executing on-change if the query text is under 4 characters in length to avoid accidental large queries, or if SID returns empty.

cheers.
